### PR TITLE
change the dependency with coffescript. it is conflicting with other pac...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "laravel/framework": ">=4.0",
-        "coffeescript/coffeescript": "dev-master"
+        "coffeescript/coffeescript": "*"
     },
     "replace": {
         "ellicom/coffee": "*"


### PR DESCRIPTION
The package expects coffeescript from dev-master. The most versions of stable packages expects stable versions of dependencies. For example the asset-pipeline package expects specifically the version 1.3.1 of coffescript.
